### PR TITLE
Use npm as publishing registry.

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-      - run: npm install
-      - run: npm publish
-        env:
-          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+      - run: npm ci
+      - uses: JS-DevTools/npm-publish@v1
+        with:
+          token: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -24,8 +24,7 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 12
-          registry-url: https://npm.pkg.github.com/
       - run: npm install
       - run: npm publish
         env:
-          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,2 @@
 node_modules/
 test/coverage
-.idea
-*.iml

--- a/.npmignore
+++ b/.npmignore
@@ -2,3 +2,4 @@ node_modules/
 test/coverage
 .idea
 *.iml
+.github

--- a/README.md
+++ b/README.md
@@ -10,11 +10,6 @@ Simple and lightweight base classes for web components with a beautiful API
 
 #### Installation
 
-create a `.npmrc` file in your project root and add the following line to set the registry for packages in `@webtides` scope. 
-```sh
-@webtides:registry=https://npm.pkg.github.com/
-```                                                                  
-
 install `element-js`
 
 ```sh

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@webtides/element-js",
-	"version": "0.3.1-publish.01",
+	"version": "0.3.1-publish.0.1",
 	"module": "index.js",
 	"repository": "https://github.com/webtides/element-js.git",
 	"author": "@webtides",

--- a/package.json
+++ b/package.json
@@ -3,9 +3,6 @@
 	"version": "0.3.1",
 	"module": "index.js",
 	"repository": "https://github.com/webtides/element-js.git",
-	"publishConfig": {
-		"registry": "https://npm.pkg.github.com/"
-	},
 	"author": "@webtides",
 	"dependencies": {
 		"lit-html": "^1.2.1"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@webtides/element-js",
-	"version": "0.3.1",
+	"version": "0.3.1-publish.01",
 	"module": "index.js",
 	"repository": "https://github.com/webtides/element-js.git",
 	"author": "@webtides",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "@webtides/element-js",
-	"version": "0.3.1-publish.0.1",
+	"version": "0.3.1",
 	"module": "index.js",
 	"repository": "https://github.com/webtides/element-js.git",
 	"author": "@webtides",


### PR DESCRIPTION
Closes #20 .

Removed the references to the github package registry.

~~Still TODO: We need to save the NPM publishing token inside the NPM_TOKEN secret. I don't seem to have enough rights.~~