### PR TITLE
Fix/watcher for injected only properties

### DIFF
--- a/src/util/Store.js
+++ b/src/util/Store.js
@@ -18,7 +18,6 @@ export class Store {
 					return this._state[key];
 				},
 				set: (newValue) => {
-					const oldState = structuredClone(this._state);
 					const oldValue = this._state[key];
 					this._state[key] = newValue;
 
@@ -27,7 +26,7 @@ export class Store {
 						if (watch.hasOwnProperty(key) && typeof watch[key] === 'function') {
 							watch[key](newValue, oldValue);
 						}
-						this.requestUpdate(oldState);
+						this.requestUpdate();
 					}
 				},
 			});
@@ -69,7 +68,7 @@ export class Store {
 		this._observer.delete(observer);
 	}
 
-	requestUpdate(oldState) {
+	requestUpdate() {
 		this._observer.forEach(async (observer) => {
 			if (observer instanceof BaseElement) {
 				await observer.requestUpdate();
@@ -78,10 +77,10 @@ export class Store {
 					// observer actually has watched properties
 					const properties = observer.properties();
 					Object.keys(observer.watch() ?? {}).forEach((key) => {
-						if (properties[key] === this) {
+						if (observer._state[key] === this) {
 							// observer is actually watching store changes provide new and old values
-							observer.callPropertyWatcher(key, this._state, oldState);
-							observer.notifyPropertyChange(key, this._state);
+							observer.callPropertyWatcher(key, this, this);
+							observer.notifyPropertyChange(key, this);
 						}
 					});
 				}

--- a/test/unit/context-protocol.test.html
+++ b/test/unit/context-protocol.test.html
@@ -102,6 +102,7 @@
 					simpleContext: '',
 					multiContext: '',
 					inlineCallbackValue: '',
+					watcherReflectedValue: false
 				};
 			}
 
@@ -114,7 +115,7 @@
 					simpleContext: '',
 					ancestorContext: null,
 					multiContext: null,
-					storeContext: null,
+					storeContext: {},
 					noContext: 'noContext',
 					staticContext: 'noContext',
 					booleanContext: true,
@@ -123,6 +124,16 @@
 					}
 				};
 			}
+
+			watch() {
+				return {
+					storeContext: (newValues) => {
+						console.log('change', newValues.value, this.storeContext.value)
+						this.watcherReflectedValue = newValues.value;
+					}
+				}
+			}
+
 
 			connected() {
 				this.requestContext('callbackContext', (context) => {
@@ -240,6 +251,16 @@
 			const el = document.getElementById('primary');
 			expect(el.inlineCallbackValue).to.equal(ParentContextElement.INLINE);
 		});
+
+		it('Does receive watcher calls through Store updates even if defaults were defined ', async () => {
+			const el = document.getElementById('primary');
+			// TODO be sure to ignore injection cals
+			el.storeContext.value = 600;
+			// need to await one update
+			await nextFrame();
+			expect(el.watcherReflectedValue).to.equal(el.storeContext.value);
+		});
+
 	});
 </script>
 </body>

--- a/test/unit/context-protocol.test.html
+++ b/test/unit/context-protocol.test.html
@@ -102,7 +102,7 @@
 					simpleContext: '',
 					multiContext: '',
 					inlineCallbackValue: '',
-					watcherReflectedValue: false
+					watcherReflectedValue: 0
 				};
 			}
 
@@ -254,7 +254,6 @@
 
 		it('Does receive watcher calls through Store updates even if defaults were defined ', async () => {
 			const el = document.getElementById('primary');
-			// TODO be sure to ignore injection cals
 			el.storeContext.value = 600;
 			// need to await one update
 			await nextFrame();


### PR DESCRIPTION
fix(store-injection-watcher): fix a bug where watchers were not triggered as the lookup in properties() was wrong.

Stores can also be injected and will never show up in the return of the properties map rather than in the injectProperties map.
It`s way easier to directly check if the changed Store instance is in the observers state as this is where the values actually live.

Also removes the attempt to provide new/old Store Values to the watch Callbacks as this was changing the model passed to the callback between store to property assignment (injection OR direct) and internal changes.