### PR TITLE
Feature/storeception

### DIFF
--- a/test/unit/store.watch.test.js
+++ b/test/unit/store.watch.test.js
@@ -15,12 +15,19 @@ class WatchStore extends Store {
 	echoOldCount = -1;
 	triggerCount = 0;
 	echoNestedStoreCount = 0;
+	updateCount = 0;
 	properties() {
 		return {
 			count: 0,
 			nestedStore: new NestedStore(),
 		};
 	}
+
+	requestUpdate() {
+		super.requestUpdate();
+		this.updateCount++;
+	}
+
 	watch() {
 		return {
 			count: (newCount, oldCount) => {
@@ -59,7 +66,7 @@ describe('store-watch', () => {
 		assert.equal(watchStore.triggerCount, 2);
 	});
 
-	it('watches changes on nested store properties which are in itself instances of Store', async () => {
+	it('Call watcher on nested store properties which are itself instances of Store', async () => {
 		const watchStore = new WatchStore({ count: 0 });
 		assert.equal(watchStore.nestedStore.nestedCount, 0);
 		watchStore.nestedStore.nestedCount = 1;
@@ -67,5 +74,13 @@ describe('store-watch', () => {
 		// store updates contains a potential await requestUpdate so we need to wait a frame here
 		await nextFrame();
 		assert.equal(watchStore.echoNestedStoreCount, watchStore.nestedStore.nestedCount);
+	});
+
+	it('updates on nested store properties changes', async () => {
+		const watchStore = new WatchStore({ count: 0 });
+		assert.equal(watchStore.nestedStore.nestedCount, 0);
+		watchStore.nestedStore.nestedCount++;
+		await nextFrame();
+		assert.equal(watchStore.updateCount, 1);
 	});
 });

--- a/test/unit/store.watch.test.js
+++ b/test/unit/store.watch.test.js
@@ -29,8 +29,6 @@ class WatchStore extends Store {
 				this.triggerCount++;
 			},
 			nestedStore: () => {
-				console.log('BLOODY CALLBACK !?');
-				console.log(this.nestedStore.nestedCount);
 				this.echoNestedStoreCount = this.nestedStore.nestedCount;
 			},
 		};

--- a/test/unit/store.watch.test.js
+++ b/test/unit/store.watch.test.js
@@ -29,6 +29,7 @@ class WatchStore extends Store {
 				this.triggerCount++;
 			},
 			nestedStore: () => {
+				console.log('BLOODY CALLBACK !?');
 				console.log(this.nestedStore.nestedCount);
 				this.echoNestedStoreCount = this.nestedStore.nestedCount;
 			},
@@ -63,9 +64,10 @@ describe('store-watch', () => {
 	it('watches changes on nested store properties which are in itself instances of Store', async () => {
 		const watchStore = new WatchStore({ count: 0 });
 		assert.equal(watchStore.nestedStore.nestedCount, 0);
-
 		watchStore.nestedStore.nestedCount = 1;
 		assert.equal(watchStore.nestedStore.nestedCount, 1);
+		// store updates contains a potential await requestUpdate so we need to wait a frame here
+		await nextFrame();
 		assert.equal(watchStore.echoNestedStoreCount, watchStore.nestedStore.nestedCount);
 	});
 });

--- a/test/unit/store.watch.test.js
+++ b/test/unit/store.watch.test.js
@@ -2,13 +2,23 @@
 import { fixture, defineCE, assert, nextFrame } from '@open-wc/testing';
 import { Store } from '../../src/util/Store';
 
+class NestedStore extends Store {
+	properties() {
+		return {
+			nestedCount: 0,
+		};
+	}
+}
+
 class WatchStore extends Store {
 	echoCount = -1;
 	echoOldCount = -1;
 	triggerCount = 0;
+	echoNestedStoreCount = 0;
 	properties() {
 		return {
 			count: 0,
+			nestedStore: new NestedStore(),
 		};
 	}
 	watch() {
@@ -17,6 +27,10 @@ class WatchStore extends Store {
 				this.echoCount = newCount;
 				this.echoOldCount = oldCount;
 				this.triggerCount++;
+			},
+			nestedStore: () => {
+				console.log(this.nestedStore.nestedCount);
+				this.echoNestedStoreCount = this.nestedStore.nestedCount;
 			},
 		};
 	}
@@ -44,5 +58,14 @@ describe('store-watch', () => {
 		// this should trigger the watcher as the value is changed
 		watchStore.count = 2;
 		assert.equal(watchStore.triggerCount, 2);
+	});
+
+	it('watches changes on nested store properties which are in itself instances of Store', async () => {
+		const watchStore = new WatchStore({ count: 0 });
+		assert.equal(watchStore.nestedStore.nestedCount, 0);
+
+		watchStore.nestedStore.nestedCount = 1;
+		assert.equal(watchStore.nestedStore.nestedCount, 1);
+		assert.equal(watchStore.echoNestedStoreCount, watchStore.nestedStore.nestedCount);
 	});
 });


### PR DESCRIPTION
This creates tha ability to watch stores in  stores.

For instance we could have a filterStore within a dataStore.

datasStore watches changes to filterStore and reloads filtered data.

dataStore is provided to a List UI
filterStore is provided to the filter UI

doing so we have better control which components are updating by splitting large logic heavy stores into mulitple smaller ones while maintaining reactivity.
