### PR TITLE
feat(defer): adds option to defer the entire connectedCallback.

### DIFF
--- a/docs/concepts/classes.md
+++ b/docs/concepts/classes.md
@@ -46,6 +46,35 @@ render (if template was provided) initially. This might be necessary in some cas
 your element before actually rendering for the first time. You will have to call the `requestUpdate` method manually at
 the right lifecycle hook.
 
+#### deferUpdate via attribute
+
+deferUpdate can also be set to true by adding a "defer-update" attribute to the host element.
+
+```html 
+<deferred-element defer-update></deferred-element>
+```
+
+#### deferConnected (⚠️)
+
+Type: `boolean` Default: `false`
+
+When set to `true` the element will early return from the native `connectedCallback()`.
+Setting this to true will defer the entire initialization of `element-js` feature set. 
+To make the element useful at a later point again `connectedCallback()` must be called at a later point.   
+
+This is an advanced Setting and should be used with great caution.
+
+
+#### deferConnected via attribute (⚠️)
+
+deferConnected can also be set to true by adding a "defer-connected" attribute to the host element.
+
+```html 
+<deferred-element defer-connected></deferred-element>
+```
+
+
+
 #### mutationObserverOptions
 
 Type: `object` Default: `{ "attributes": true, "childList": true, "subtree": false }`

--- a/src/BaseElement.js
+++ b/src/BaseElement.js
@@ -17,6 +17,7 @@ class BaseElement extends HTMLElement {
 		this._options = {
 			autoUpdate: true,
 			deferUpdate: true,
+			deferConnected: false,
 			mutationObserverOptions: {
 				attributes: true,
 				childList: true,
@@ -27,6 +28,13 @@ class BaseElement extends HTMLElement {
 			...options,
 		};
 
+		if (this.hasAttribute('defer-update')) {
+			this._options.deferUpdate = true;
+		}
+		if (this.hasAttribute('defer-connected')) {
+			this._options.deferConnected = true;
+		}
+
 		if (options.childListUpdate !== undefined && options.childListUpdate !== null) {
 			this._options.mutationObserverOptions.childList = options.childListUpdate;
 			console.warn(
@@ -36,6 +44,11 @@ class BaseElement extends HTMLElement {
 	}
 
 	connectedCallback() {
+		if (this._options.deferConnected) {
+			this._options.deferConnected = false;
+			return;
+		}
+
 		// define all attributes to "this" as properties
 		this.defineAttributesAsProperties();
 
@@ -51,7 +64,7 @@ class BaseElement extends HTMLElement {
 		// define everything that should be observed
 		this.defineObserver();
 
-		if (this.hasAttribute('defer-update') || this._options.deferUpdate) {
+		if (this._options.deferUpdate) {
 			// don't updates/render, but register refs and events
 			this.registerEventsAndRefs();
 

--- a/test/unit/options.test.js
+++ b/test/unit/options.test.js
@@ -1,25 +1,25 @@
 /* eslint-disable no-unused-expressions */
-import { fixture, defineCE, assert } from '@open-wc/testing';
+import { fixture, defineCE, assert, nextFrame } from '@open-wc/testing';
 import { BaseElement } from '../../src/BaseElement';
+class ImmediateElement extends BaseElement {
+	constructor() {
+		super({ deferUpdate: false });
+	}
 
-const immediateTag = defineCE(
-	class extends BaseElement {
-		constructor() {
-			super({ deferUpdate: false });
-		}
+	properties() {
+		return {
+			updateCalled: false,
+			count: 0,
+		};
+	}
 
-		properties() {
-			return {
-				updateCalled: false,
-			};
-		}
+	update(options = { notify: true }) {
+		this.updateCalled = true;
+		super.update(options);
+	}
+}
 
-		update(options = { notify: true }) {
-			this.updateCalled = true;
-			super.update(options);
-		}
-	},
-);
+const immediateTag = defineCE(ImmediateElement);
 
 describe('options', () => {
 	it('can disable initial rendering via attribute', async () => {
@@ -29,6 +29,32 @@ describe('options', () => {
 
 	it('will update immediately if deferUpdate:true is passed via constructor options', async () => {
 		const el = await fixture(`<${immediateTag}></${immediateTag}>`);
+		assert.isTrue(el.updateCalled);
+	});
+
+	it('can defer initalization in connectedCallback via attribute', async () => {
+		const el = await fixture(`<${immediateTag} defer-connected></${immediateTag}>`);
+		// properties wil not be defined
+		assert.isUndefined(el.updateCalled);
+	});
+	it('can initalize by calling connectedCallback manually', async () => {
+		const el = await fixture(`<${immediateTag} defer-connected></${immediateTag}>`);
+		el.connectedCallback();
+		// properties wil be defined
+		assert.isDefined(el.count);
+		el.count++;
+		await nextFrame();
+		assert.isTrue(el.updateCalled);
+	});
+
+	it('can handle both defer-update and defer-connected on the same element', async () => {
+		const el = await fixture(`<${immediateTag} defer-update defer-connected></${immediateTag}>`);
+		el.connectedCallback();
+		// properties wil be defined
+		assert.isFalse(el.updateCalled);
+		assert.isDefined(el.count);
+		el.count++;
+		await nextFrame();
 		assert.isTrue(el.updateCalled);
 	});
 });


### PR DESCRIPTION
This can be useful if we want to actually defer the entire initialization until some point in time. Clean up attribute evaluation.
Add Docs for the attribute options.