### PR TITLE
fix(globalStyles): catch security errors when GSS tries to read css r…

### DIFF
--- a/src/util/GlobalStylesStore.js
+++ b/src/util/GlobalStylesStore.js
@@ -53,7 +53,11 @@ class GlobalStylesStore extends Store {
 				if (styleSheet.ownerNode.tagName === 'STYLE') {
 					cssStyleSheet.replaceSync(styleSheet.ownerNode.textContent);
 				} else if (styleSheet.ownerNode.tagName === 'LINK') {
-					Array.from(styleSheet.cssRules).map((rule) => cssStyleSheet.insertRule(rule.cssText));
+					try {
+						Array.from(styleSheet?.cssRules ?? []).map((rule) => cssStyleSheet.insertRule(rule.cssText));
+					} catch (e) {
+						console.error('GlobalStylesStore: cannot read cssRules.', e);
+					}
 				}
 			}
 			cssStyleSheets.push(cssStyleSheet);

--- a/src/util/GlobalStylesStore.js
+++ b/src/util/GlobalStylesStore.js
@@ -56,7 +56,7 @@ class GlobalStylesStore extends Store {
 					try {
 						Array.from(styleSheet?.cssRules ?? []).map((rule) => cssStyleSheet.insertRule(rule.cssText));
 					} catch (e) {
-						console.error('GlobalStylesStore: cannot read cssRules.', e);
+						console.error('GlobalStylesStore: cannot read cssRules. Maybe add crossorigin="anonymous" to your style link?', e);
 					}
 				}
 			}

--- a/test/unit/element-styles.test.html
+++ b/test/unit/element-styles.test.html
@@ -11,6 +11,10 @@
 			}
 		</style>
 		<link rel="stylesheet" href="./element-styles1.test.css" />
+		<!-- x origin style cssRules cannot be read by GlobalStyleStore-->
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" >
+		<!-- x origin style cssRules can be read can when crossorigin attribute is present-->
+		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/tailwindcss/2.2.19/tailwind.min.css" crossorigin="anonymous">
 	</head>
 	<body>
 		<style>


### PR DESCRIPTION
…ules from cross origin stylesheets.

The error was causing the entoire style adoption to fail.