### PR TITLE
 feat(ejs): render and attach shadowroot in the same tick.

### DIFF
--- a/src/StyledElement.js
+++ b/src/StyledElement.js
@@ -39,17 +39,6 @@ class StyledElement extends BaseElement {
                 return cssStyleSheet;
             });
         }
-
-        if (supportsAdoptingStyleSheets() && this._options.shadowRender) {
-            // adopting does only make sense in shadow dom. Fall back to append for light elements
-            this.adoptStyleSheets();
-
-            if (this._options.adoptGlobalStyles !== false) {
-                globalStylesStore.subscribe(() => {
-                    this.adoptStyleSheets();
-                });
-            }
-        }
     }
 
     /**
@@ -71,6 +60,26 @@ class StyledElement extends BaseElement {
             this.appendStyleSheets();
         }
         super.update(options);
+    }
+
+    /**
+     * Start the adoption of external stylesheets
+     * adopt global styles from document
+     * subscribe to globalStylesStore for updates
+     * @returns { void }
+     */
+
+    initStyleAdoption() {
+        if (this._options.shadowRender && supportsAdoptingStyleSheets()) {
+            // adopting does only make sense in shadow dom. Fall back to append for light elements
+            this.adoptStyleSheets();
+
+            if (this._options.adoptGlobalStyles !== false) {
+                globalStylesStore.subscribe(() => {
+                    this.adoptStyleSheets();
+                });
+            }
+        }
     }
 
     /**

--- a/src/TemplateElement.js
+++ b/src/TemplateElement.js
@@ -28,7 +28,6 @@ class TemplateElement extends StyledElement {
 
     /**
      * Overrides the native `connectedCallback` of the HTMLElement to set up and initialize our element.
-     * This will attach a shadow DOM if the element is supposed to render in shadow DOM.
      */
     connectedCallback() {
         super.connectedCallback();
@@ -47,20 +46,22 @@ class TemplateElement extends StyledElement {
      * @param {PropertyUpdateOptions} options
      */
     update(options) {
-        let firstRender = this._options.shadowRender && !this.shadowRoot;
-        if (firstRender) {
-            this.attachShadow({ mode: 'open' });
-            // adopt stylesheets
-            this.adoptStyleSheets();
-        }
         this.renderTemplate();
         super.update(options);
     }
 
     /**
      * Render the template to the root
+     * This will attach a shadow DOM if the element is supposed to render in shadow DOM.
      */
     renderTemplate() {
+        let firstRender = this._options.shadowRender && !this.shadowRoot;
+        if (firstRender) {
+            this.attachShadow({ mode: 'open' });
+            // adopt stylesheets
+            this.adoptStyleSheets();
+        }
+
         const template = this._template || this.template();
         render(template, this.getRoot());
     }

--- a/src/TemplateElement.js
+++ b/src/TemplateElement.js
@@ -31,7 +31,6 @@ class TemplateElement extends StyledElement {
      * This will attach a shadow DOM if the element is supposed to render in shadow DOM.
      */
     connectedCallback() {
-        if (this._options.shadowRender && !this.shadowRoot) this.attachShadow({ mode: 'open' });
         super.connectedCallback();
     }
 
@@ -48,6 +47,12 @@ class TemplateElement extends StyledElement {
      * @param {PropertyUpdateOptions} options
      */
     update(options) {
+        let firstRender = this._options.shadowRender && !this.shadowRoot;
+        if (firstRender) {
+            this.attachShadow({ mode: 'open' });
+            // adopt stylesheets
+            this.adoptStyleSheets();
+        }
         this.renderTemplate();
         super.update(options);
     }

--- a/src/TemplateElement.js
+++ b/src/TemplateElement.js
@@ -55,11 +55,11 @@ class TemplateElement extends StyledElement {
      * This will attach a shadow DOM if the element is supposed to render in shadow DOM.
      */
     renderTemplate() {
-        let firstRender = this._options.shadowRender && !this.shadowRoot;
+        const firstRender = this._options.shadowRender && !this.shadowRoot;
         if (firstRender) {
             this.attachShadow({ mode: 'open' });
-            // adopt stylesheets
-            this.adoptStyleSheets();
+            // init external stylesheets
+            this.initStyleAdoption();
         }
 
         const template = this._template || this.template();


### PR DESCRIPTION
Currently we have an animation frame between connection of an element and the first render cycle.

I ran into a bug today while rendering a Shadow Element as we actually attach the ShadowRoot on connected but actually render not until the requested update is performed.

That leaves the element in a state where the light dome is kind of "detached" from the DOM.

That leads to eg. nested elements having NO offsetParent and no dimensions at all:
<img width="880" height="985" alt="screenshot_mh 2025-09-04 um 15 24 33" src="https://github.com/user-attachments/assets/2c177b98-3e32-41ca-9d82-4323d539dae5" />


With this change i would like to keep the SR Attache and the first render in the same tick.

Is there any reason why we should not do it like this @eddyloewen !?



